### PR TITLE
Fix for UFix64 Dictionary decoding

### DIFF
--- a/Sources/Flow/Decode/FlowArgument+Decode.swift
+++ b/Sources/Flow/Decode/FlowArgument+Decode.swift
@@ -130,17 +130,24 @@ extension Flow.Argument: FlowCodable {
             }
 
             // TODO: Improve this
-            if result.first?.key.type == .int {
+            switch result.first?.key.type {
+            case .int:
                 return result.reduce(into: [Int: Any?]()) {
                     if let key = $1.key.decode() as? Int {
                         $0[key] = $1.value.decode()
                     }
                 }
-            }
-
-            return result.reduce(into: [String: Any?]()) {
-                if let key = $1.key.decode() as? String {
-                    $0[key] = $1.value.decode()
+            case .ufix64:
+                return result.reduce(into: [Double: Any?]()) {
+                    if let key = $1.key.decode() as? Double {
+                        $0[key] = $1.value.decode()
+                    }
+                }
+            default:
+                return result.reduce(into: [String: Any?]()) {
+                    if let key = $1.key.decode() as? String {
+                        $0[key] = $1.value.decode()
+                    }
                 }
             }
         case .path:


### PR DESCRIPTION
This fix corrects the decode function from returning an empty dictionary when the key type is UFix64 in Cadence. Looks like this may need to be done for any none string type but further testing is needed.